### PR TITLE
Remove sample NavLink from SiteHeader

### DIFF
--- a/components/site-header.tsx
+++ b/components/site-header.tsx
@@ -93,7 +93,6 @@ export default function SiteHeader() {
         {/* Right: Nav + Mobile menu button */}
         <nav className="hidden items-center gap-1 md:flex">
           <NavLink href="/">Catalogue</NavLink>
-          <NavLink href="/poem/rain-song">Sample</NavLink>
           <NavLink href="/api/poems">API</NavLink>
         </nav>
 


### PR DESCRIPTION
Eliminate the sample NavLink from the SiteHeader component to streamline navigation options.